### PR TITLE
Export `CommonRequest` from `buildContext` file

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -1,0 +1,38 @@
+# This action checks all aspects of the code to ensure it is a compliant change, as
+#   determined by the scirpts we have in npm.
+name: All checks
+
+# Controls when the workflow will run
+on:
+  # Triggers this workflow on push to the main branch
+  push:
+    branches: [main]
+
+  # Triggers this workflow on all pull requests to main
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci && npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci && CI=true npm run test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci && CI=true npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -4979,9 +4979,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001514",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
-      "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==",
+      "version": "1.0.30001579",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
       "dev": true,
       "funding": [
         {

--- a/src/buildContext.ts
+++ b/src/buildContext.ts
@@ -44,7 +44,7 @@ const promisifiedLogout = (req: express.Request, options?: { keepSessionInfo?: b
     req.logout(options, done);
   });
 
-interface CommonRequest<UserObjectType extends Express.User>
+export interface CommonRequest<UserObjectType extends Express.User>
   extends Pick<Context<UserObjectType>, 'isAuthenticated' | 'isUnauthenticated'> {
   user?: UserObjectType;
 }


### PR DESCRIPTION
There was a typescript issue where we didn't export one of the types we were using, leading to not being able to export a type depending on it with `declaration: true` in your config.

Fixes #93